### PR TITLE
User protocol relative urls

### DIFF
--- a/Package/Captcha/Captcha.php
+++ b/Package/Captcha/Captcha.php
@@ -45,13 +45,6 @@ class Captcha
      *
      * @var string
      */
-
-    /**
-     * reCaptcha's secure API server
-     *
-     * @var string
-     */
-    const SERVER_SECURE = 'https://www.google.com/recaptcha/api';
     const SERVER = '//www.google.com/recaptcha/api';
 
     /**
@@ -81,34 +74,6 @@ class Captcha
      * @var string
      */
     protected $error;
-
-    /**
-     * Flag to use SSL for our request(s)
-     *
-     * @var bool
-     */
-    protected $isSsl = false;
-
-    /**
-     * Set SSL flag
-     *
-     * @param bool $flag
-     * @return void
-     */
-    public function setSsl($flag = true)
-    {
-        $this->isSsl = (bool) $flag;
-    }
-
-    /**
-     * Check if SSL is currently enabled
-     *
-     * @return bool
-     */
-    public function isSsl()
-    {
-        return (bool) $this->isSsl;
-    }
 
     /**
      * Set public key
@@ -186,12 +151,6 @@ class Captcha
     {
         if (!$this->getPublicKey()) {
             throw new Exception('You must set public key provided by reCaptcha');
-        }
-
-        if ($this->isSsl()) {
-            $server = self::SERVER_SECURE;
-        } else {
-            $server = self::SERVER;
         }
 
         $error = ($this->getError() ? '&amp;error=' . $this->getError() : null);


### PR DESCRIPTION
Hi,

I noticed that you are using a method to let the client configure if he wants to use the SSL api. This could be decided automatically by the browser by using protocol relative URL's. I do this all the time in my projects.

Tell me if i'm missing something, but i think the user doesn't need to specify if he wants to use SSL or not, he probably expects that we do the right thing (use SSL if we are in an SSL page, don't use it if we aren't).

Let me know what you think about this.

Cheers.
